### PR TITLE
- ソーシャルログイン関数を共通化

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -98,17 +98,21 @@ function jumpToFacebookLoginLink(){
 	loginClient.send();
 }
 
-function jumpToTwitterLoginLink(){
-	var url = Alloy.Globals.config.baseurl;
+// アプリのトップ画面からソーシャルログインを選択した場合に、Web画面トップにあるソーシャルログインリンクを自動的に踏ませるための関数です。
+// @pattern: String ソーシャルログインボタンのhref属性にマッチする正規表現パターン
+function jumpToSocialLoginLink(pattern){
 	var loginClient = Ti.Network.createHTTPClient({
-		onload: function(e){			
+		onload: function(e){
+			// 正規表現でログインリンクを取得
+			// もしマッチしなかった場合はトップページに遷移しますが、単なる異常終了回避なので、正規表現を確認しなおしてください。
+			var url = this.responseText.match(pattern)?this.responseText.match(pattern)[0]:Alloy.Globals.config.baseurl;
 			var mainController = Alloy.createController('main',{
-				url: Alloy.Globals.config.baseurl,
-				twitterlogin: true
+				url: url
 			});
 			var mainWin = mainController.getView();
 			if(osname == 'android'){
 				// Save cookie for Android WebView
+				// Android端末の場合、WebViweのCookieがアプリのCookieと同期しないので、手動でセットしてやる必要があります。
 				var cookies = Ti.Network.getHTTPCookiesForDomain(Alloy.Globals.config.domain);
 				cookies.forEach(function(cookie){
 					Ti.Network.addSystemCookie(cookie);
@@ -123,9 +127,15 @@ function jumpToTwitterLoginLink(){
 		},
 		timeout: 8000
 	});
-	loginClient.open("GET", url); 
+	loginClient.open("GET", Alloy.Globals.config.baseurl);
 	loginClient.send();
 }
+
+function jumpToTwitterLoginLink(){
+	var pattern = /https:\/\/api.twitter.com\/oauth\/authenticate\?oauth_token=[0-9a-zA-Z-_]*/;
+	jumpToSocialLoginLink(pattern);
+}
+
 
 function loginByFacebook(){
 	facebook.authorize();

--- a/app/controllers/main.js
+++ b/app/controllers/main.js
@@ -1,13 +1,8 @@
 var args = arguments[0] || {};
 var url = args.url || Alloy.Globals.config.baseurl;
 var loginId = args.loginId || '';
-var twitterlogin = args.twitterlogin || false;
 var mainWebView = $.mainTab.getView('mainWebView');
 mainWebView.url = url;
-
-if(twitterlogin){
-	mainWebView.addEventListener('load', jumpToTwitterLoginLink);
-}
 
 // configurataion of the back button of android
 $.mainTabGroup.addEventListener("androidback", function(){
@@ -31,16 +26,4 @@ function openTroubleshootingWindow(){
 	    modalTransitionStyle: Ti.UI.iPhone.MODAL_TRANSITION_STYLE_COVER_VERTICAL,
 	    modalStyle: Ti.UI.iPhone.MODAL_PRESENTATION_FORMSHEET
 	});
-}
-
-function jumpToTwitterLoginLink(){
-	// get link of twitter login button
-	var loginUrl = "";
-	loginUrl = mainWebView.evalJS('
-		document.getElementsByClassName("wpg_tw_btn")?document.getElementsByClassName("wpg_tw_btn")[0].href:""
-	');
-	if(loginUrl && loginUrl !== "undefined"){
-		mainWebView.url = loginUrl;
-	}
-	mainWebView.removeEventListener('load', jumpToTwitterLoginLink);
 }


### PR DESCRIPTION
- Twitterログインの場合、従来は一度トップページに遷移してからログインリンクを踏ませていたのを、直接リンクを踏ませるように変更。これにより、Android端末でTwitterログイン後にトップページで処理が固まる現象を解消